### PR TITLE
feat: Create webterminal-proxy repository

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -70,6 +70,10 @@ orgs:
         default_branch: main
         description: Assemble Software Template (Backstage)
         has_projects: true
+      webterminal-proxy:
+        default_branch: main
+        description: Proxy for web terminal plugin
+        has_projects: false
     teams:
       assemble:
         description: Assemble Project Dev Team


### PR DESCRIPTION
This repo is meant to host a golang websocket proxy, since kubernetes websocket support is insufficient and backstage proxy supports http proxying only.

This is a workaround very similar to what openshift console uses.