### PR TITLE
feat: Add shared actions and a workflow for the org

### DIFF
--- a/.github/actions/build-and-push/action.yaml
+++ b/.github/actions/build-and-push/action.yaml
@@ -1,0 +1,57 @@
+name: build-and-push
+description: Build and/or push an image to a repository with a given platform
+
+inputs:
+  platform:
+    description: Platform to build with, e.g. linux/amd64
+    required: true
+  image_tag:
+    description: Image tag to tag image with, e.g. latest
+    required: true
+  context:
+    description: Context to build the image with
+    required: false
+    default: .
+  push:
+    description: Whether to push to a registry or not
+    default: "true"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Job Variables
+      shell: bash
+      id: set-build-variables
+      run: |
+        echo "PLATFORM_DASH=$(echo ${{ inputs.platform }} | sed -e 's/\//-/g')" >> $GITHUB_OUTPUT
+        if [ -z "$MAIN_REGISTRY" ] && [ -z "$MAIN_REPOSITORY" ]; then
+          echo "MAIN_REGISTRY=foo" >> $GITHUB_ENV
+          echo "MAIN_REPOSITORY=bar" >> $GITHUB_ENV
+        fi
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 #pin@v2.1.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 #pin@v2.2.1
+
+    - if: inputs.push == 'true'
+      name: Log in to Registry
+      uses: redhat-actions/podman-login@632d91dfe19e1b55833cb708786bfbad2c2a0335 #pin@v3.2.0
+      with:
+        registry: ${{ env.MAIN_REGISTRY }}
+        username: ${{ env.MAIN_USERNAME }}
+        password: ${{ env.MAIN_PASSWORD }}
+
+    - name: Build container image
+      uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 #pin@v3.3.0
+      with:
+        context: ${{ inputs.context }}
+        file: Dockerfile
+        platforms: ${{ inputs.platform }}
+        provenance: false
+        push: ${{ inputs.push }}
+        tags: |
+          ${{ env.MAIN_REGISTRY }}/${{ env.MAIN_REPOSITORY }}:latest-${{ steps.set-build-variables.outputs.PLATFORM_DASH }}
+          ${{ env.MAIN_REGISTRY }}/${{ env.MAIN_REPOSITORY }}:${{ inputs.image_tag }}-${{ steps.set-build-variables.outputs.PLATFORM_DASH }}

--- a/.github/actions/mirror-images-and-create-manifests/action.yaml
+++ b/.github/actions/mirror-images-and-create-manifests/action.yaml
@@ -1,0 +1,83 @@
+name: mirror-images-and-create-manifests
+description: Mirror one image with multiple arcs to multiple image repos
+
+inputs:
+  image_platform_tags:
+    description: Platform tags in a space separated string, e.g. linux-amd64 linux-arm64
+    required: true
+  image_tag:
+    description: Image tag to prefix all image platform tags
+    required: true
+  registry:
+    description: Registry
+    required: true
+  username:
+    description: Registry username for pushing images/manifests
+    required: true
+  password:
+    description: Registry password for pushing images/manifests
+    required: true
+  repository:
+    description: Registry repository for pushing images/manifests
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Log in to Registry to pull images
+      uses: redhat-actions/podman-login@632d91dfe19e1b55833cb708786bfbad2c2a0335 #pin@v3.2.0
+      with:
+        registry: ${{ env.MAIN_REGISTRY }}
+        username: ${{ env.MAIN_USERNAME }}
+        password: ${{ env.MAIN_PASSWORD }}
+
+    - name: Import Docker images
+      shell: bash
+      run: |
+        for PLATFORM in ${{ inputs.image_platform_tags }}; do \
+          PLATFORM_SLASH=$(echo $PLATFORM | sed -e 's/-/\//g')
+          for TAG in latest ${{ inputs.image_tag }}; do \
+            docker pull --platform $PLATFORM_SLASH ${{ env.MAIN_REGISTRY }}/${{ env.MAIN_REPOSITORY }}:$TAG-$PLATFORM
+          done
+        done
+
+    - name: Log out of registry
+      shell: bash
+      run: |
+        podman logout ${{ env.MAIN_REGISTRY }}
+
+    - name: Log in to Registry to push images
+      uses: redhat-actions/podman-login@632d91dfe19e1b55833cb708786bfbad2c2a0335 #pin@v3.2.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Push images
+      shell: bash
+      run: |
+        IMAGE_REPOSITORY="${{ inputs.registry }}/${{ inputs.repository }}"
+
+        for PLATFORM in ${{ inputs.image_platform_tags }}; do \
+          for TAG in latest ${{ inputs.image_tag }}; do \
+            docker tag ${{ env.MAIN_REGISTRY }}/${{ env.MAIN_REPOSITORY }}:$TAG-$PLATFORM $IMAGE_REPOSITORY:$TAG-$PLATFORM
+            docker push $IMAGE_REPOSITORY:$TAG-$PLATFORM
+          done
+        done
+
+    - name: Create and push manifests
+      shell: bash
+      run: |
+        IMAGE_REPOSITORY="${{ inputs.registry }}/${{ inputs.repository }}"
+        TAGS="latest"
+        if [[ "${{ inputs.image_tag }}" != "latest" ]]; then
+          TAGS="$TAGS ${{ inputs.image_tag }}"
+        fi
+
+        for TAG in $TAGS; do \
+          podman manifest create $IMAGE_REPOSITORY:$TAG
+          for PLATFORM in ${{ inputs.image_platform_tags }}; do \
+              podman manifest add $IMAGE_REPOSITORY:$TAG docker://$IMAGE_REPOSITORY:$TAG-$PLATFORM; \
+          done
+          podman manifest push $IMAGE_REPOSITORY:$TAG docker://$IMAGE_REPOSITORY:$TAG
+        done

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,42 @@
+name: Setup Workflow Variables
+
+on:
+  workflow_call:
+    inputs:
+      default_tag_version:
+        required: true
+        type: string
+      build_platforms:
+        required: true
+        type: string
+    outputs:
+      image_tag:
+        value: ${{ jobs.setup.outputs.image_tag }}
+      dist_matrix:
+        value: ${{ jobs.setup.outputs.dist_matrix }}
+      image_platform_tags:
+        value: ${{ jobs.setup.outputs.image_platform_tags }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Workflow Variables
+        id: set-variables
+        run: |
+          # Set versions based on presence of tag
+          if [[ "${{ github.ref }}" =~ ^refs/tags/ ]]; then
+            echo "IMAGE_TAG=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_TAG=${{ inputs.default_tag_version }}" >> $GITHUB_OUTPUT
+          fi
+
+          # Create Distribution Matrix
+          echo "DIST_MATRIX=$(echo -n "${{ inputs.build_platforms }}" | jq -csR '. | split(",")')" >> $GITHUB_OUTPUT
+          # Create Image Tags
+          echo "IMAGE_PLATFORM_TAGS=$(echo ${{ inputs.build_platforms }} | sed  -e 's/,/ /g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
+
+    outputs:
+      image_tag: ${{ steps.set-variables.outputs.IMAGE_TAG}}
+      dist_matrix: ${{ steps.set-variables.outputs.DIST_MATRIX }}
+      image_platform_tags: ${{ steps.set-variables.outputs.IMAGE_PLATFORM_TAGS }}


### PR DESCRIPTION
Related PRs: 
- https://github.com/janus-idp/redhat-backstage-build/pull/19
- https://github.com/janus-idp/webterminal-proxy/pull/6

Move `setup` workflow from https://github.com/janus-idp/redhat-backstage-build/blob/main/.github/workflows/setup.yaml to here so it can be used for building the `webterminal-proxy`.

Create two actions from https://github.com/janus-idp/redhat-backstage-build/blob/main/.github/workflows/build.yaml:
- one that builds and/or pushes the images to the main repo
- one that pulls the pushed image and creates manifests/pushes images to more repositories
