### PR TITLE
feat: add code of conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Community Code of Conduct
+
+Janus-IDP follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Adds a link to CNCF code of conduct. This serves 2 purposes:

1. We announce that we follow it (the same CoC is followed by upstream Backstage)
2. Since it's put into `.github` repository as `CODE_OF_CONDUCT.md` it gets propagated to all `janus-idp` repositories in GitHub UI. (https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)