### PR TITLE
chore: add blank issue template

### DIFF
--- a/.github/ISSUE_TEMPALTE/blank.md
+++ b/.github/ISSUE_TEMPALTE/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank Template
+about: Create a blank issue
+labels: [status/triage]
+---

--- a/.github/ISSUE_TEMPALTE/config.yml
+++ b/.github/ISSUE_TEMPALTE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Janus IDP Community Slack
+    url: https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg
+    about: Please ask and answer questions here.


### PR DESCRIPTION
### Description
Removed the ability for users to create blank issues in favor of creating a blank issue template to enforce the usage of status/triage for all issues.

### Which issue(s) does this PR fix
Fixes #25  