### PR TITLE
Add reusable add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -6,7 +6,7 @@ on:
       project_id:
         type: number
         description: The ID of the project to add the issue to
-        default: 1
+        default: 2
 jobs:
   add-issue-to-project:
     name: Add issue with `status/triage` label to project

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,0 +1,26 @@
+name: Add issue to project
+
+on:
+  workflow_call:
+    inputs:
+      project_id:
+        type: number
+        required: true
+jobs:
+  add-issue-to-project:
+    name: Add issue with `status/triage` label to project
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'status/triage' }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1.2.1
+        with:
+          # Organization Github App ID and Private Key with write permissions to organization project
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Add issue to project
+        run: gh project item-add ${{ inputs.project_id }} --owner ${{ github.event.organization.login }} --url ${{ github.event.issue.html_url }}
+        env:
+          # token needs to have read/write permissions for projects on org level
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -5,20 +5,19 @@ on:
     inputs:
       project_id:
         type: number
-        required: true
+        description: The ID of the project to add the issue to
+        default: 1
 jobs:
   add-issue-to-project:
     name: Add issue with `status/triage` label to project
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'status/triage' }}
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v1.2.1
+        uses: actions/create-github-app-token@49ce228ea7cddec9f88dd09c5b7740dbac82d7ba # v1.2.1
         with:
-          # Organization Github App ID and Private Key with write permissions to organization project
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ vars.JANUS_IDP_GITHUB_APP_ID }}
+          private_key: ${{ secrets.JANUS_IDP_GITHUB_APP_PRIVATE_KEY }}
       - name: Add issue to project
         run: gh project item-add ${{ inputs.project_id }} --owner ${{ github.event.organization.login }} --url ${{ github.event.issue.html_url }}
         env:


### PR DESCRIPTION
## Description
Add reusable add-to-project workflow to the .github repository that workflows in other repositories in the organization will reference.

Workflow will only run when the caller workflow is triggered by the `status/triage` label being applied to the issue.

## What issue(s) does this fix?
Fixes #28

## Special notes to the reviewer
This workflow will require a github app with write access to organization projects to be installed onto the organization.
The `APP_ID` should be provided as an organization variable and the `APP_PRIVATE_KEY` should be provided as an organization secret to all the repositories that use this workflow.