### PR TITLE
.github: indicate Janus IDP is deprecated

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,11 +1,13 @@
 <h2 align="center">Janus IDP</h2>
-<p align="center">A Red Hat sponsored community for building Internal Development Platforms and Plugins with backstage.io</p>
+
+<p align="center">
+The Janus IDP project is deprecated. Content and development efforts have moved to other repositories under Red Hat and the Backstage community. More context can be found in the
+<a href="https://janus-idp.io/blog/2024/07/05/future-of-janus-community">Future of the Janus Community</a> blog post.
+</p>
+
 <p align="center">
   <a href="https://janus-idp.io/">
     <img alt="Janus IDP website" src="https://img.shields.io/badge/website-janus--idp.io-blueviolet">
-  </a>
-  <a href="https://join.slack.com/t/janus-idp/shared_invite/zt-1lap9hwgi-3tm9VW8DkinqGcdRkGowlg">
-    <img alt="Join us on Slack" src="https://img.shields.io/badge/slack-Janus--IDP-brightgreen.svg?logo=slack">
   </a>
   <a href="https://www.npmjs.com/search?q=%40janus-idp">
     <img alt="NPM registry" src="https://img.shields.io/badge/npm-%40janus--idp-blue?logo=npm">
@@ -15,7 +17,10 @@
 
 ---
 
-### Important links
+## Relocated Project Components
 
-- [Code of Conduct](https://github.com/janus-idp/.github/blob/main/CODE_OF_CONDUCT.md)
-- [Governance](https://github.com/janus-idp/.github/blob/main/GOVERNANCE.md)
+- Helm chart: [redhat-developer/rhdh-chart](https://github.com/redhat-developer/rhdh-chart)  
+- Customization provider: [redhat-developer/rhdh-customization-provider](https://github.com/redhat-developer/red-hat-developer-hub-customization-provider)  
+- Software templates: [redhat-developer/rhdh-software-templates](https://github.com/redhat-developer/red-hat-developer-hub-software-templates)  
+- Plugins: [backstage/community-plugins](https://github.com/backstage/community-plugins) and [redhat-developer/rhdh-plugins](https://github.com/redhat-developer/rhdh-plugins)
+


### PR DESCRIPTION
Also remove links to Slack that is no longer active.